### PR TITLE
monitor: if no process found according to the pidfile mysql is not running

### DIFF
--- a/agents/mysql_monitor
+++ b/agents/mysql_monitor
@@ -545,6 +545,10 @@ mysql_monitor() {
                 ;;
                 
             esac
+        else
+            ocf_log $1 "MySQL is not running, but there is a pidfile"
+            set_reader_attr 0
+            set_writer_attr 0
         fi
     else
         ocf_log $1 "MySQL is not running"


### PR DESCRIPTION
This is a common situation when mysql was killed abruptly, like a OOM
scenario.

Closes #52
